### PR TITLE
Uses RuleKey instead of Rule.

### DIFF
--- a/sonar-xml-plugin/src/main/java/org/sonar/plugins/xml/XmlSensor.java
+++ b/sonar-xml-plugin/src/main/java/org/sonar/plugins/xml/XmlSensor.java
@@ -88,7 +88,7 @@ public class XmlSensor implements Sensor {
       Issuable issuable = resourcePerspectives.as(Issuable.class, sourceCode.getSonarFile());
       issuable.addIssue(
         issuable.newIssueBuilder()
-          .ruleKey(xmlIssue.getRule().ruleKey())
+          .ruleKey(xmlIssue.getRuleKey())
           .line(xmlIssue.getLine())
           .message(xmlIssue.getMessage())
           .build());

--- a/sonar-xml-plugin/src/main/java/org/sonar/plugins/xml/checks/AbstractXmlCheck.java
+++ b/sonar-xml-plugin/src/main/java/org/sonar/plugins/xml/checks/AbstractXmlCheck.java
@@ -36,7 +36,7 @@ public abstract class AbstractXmlCheck {
   }
 
   protected final void createViolation(Integer linePosition, String message) {
-    getWebSourceCode().addViolation(new XmlIssue(getWebSourceCode().getSonarFile(), rule, linePosition, message));
+    getWebSourceCode().addViolation(new XmlIssue(getWebSourceCode().getSonarFile(), rule.ruleKey(), linePosition, message));
   }
 
   protected XmlSourceCode getWebSourceCode() {

--- a/sonar-xml-plugin/src/main/java/org/sonar/plugins/xml/checks/XmlIssue.java
+++ b/sonar-xml-plugin/src/main/java/org/sonar/plugins/xml/checks/XmlIssue.java
@@ -18,6 +18,7 @@
 package org.sonar.plugins.xml.checks;
 
 import org.sonar.api.resources.File;
+import org.sonar.api.rule.RuleKey;
 import org.sonar.api.rules.Rule;
 
 /**
@@ -27,20 +28,20 @@ import org.sonar.api.rules.Rule;
  */
 public class XmlIssue {
 
-  private final Rule rule;
   private final int line;
   private final String message;
   private final File file;
+  private RuleKey ruleKey;
 
-  public XmlIssue(File file, Rule rule, int line, String message) {
+  public XmlIssue(File file, RuleKey ruleKey, int line, String message) {
     this.file = file;
-    this.rule = rule;
+    this.ruleKey = ruleKey;
     this.line = line;
     this.message = message;
   }
 
-  public Rule getRule() {
-    return rule;
+  public RuleKey getRuleKey() {
+      return ruleKey;
   }
 
   public int getLine() {


### PR DESCRIPTION
The class AnnotationCheckFactory is deprecated since 4.2. Nowhere is the Rule object self needed in this plugin.
This makes simpler to develop a plugin based on XmlPlugin, because the new plugins should use Checks.ruleKey().