### PR TITLE
Corrected S1778 rule documentation

### DIFF
--- a/sonar-xml-plugin/src/main/resources/org/sonar/l10n/xml/rules/xml/S1778.html
+++ b/sonar-xml-plugin/src/main/resources/org/sonar/l10n/xml/rules/xml/S1778.html
@@ -12,20 +12,19 @@ This requirement is explicitly defined in the XML specification:
 Because each XML entity not accompanied by external encoding information and not in UTF-8 or UTF-16 encoding must begin with an XML encoding declaration, in which the first characters must be '&lt?xml', any conforming processor can detect, after two to four octets of input, which of the following cases apply.
 </blockquote>
 
-
-<h2>Noncompliant Example</h2>
+<h2>Noncompliant Code Sample</h2>
 <pre>
-<!-- Generated file -->
+&lt!-- Generated file --&gt
 &lt?xml version="1.0" encoding="UTF-8"?&gt
 &ltfirstNode&gt
   content
 &lt/firstNode&gt
 </pre>
 
-<h2>Noncompliant Example</h2>
+<h2>Compliant Solution</h2>
 <pre>
-<!-- Generated file -->
 &lt?xml version="1.0" encoding="UTF-8"?&gt
+&lt!-- Generated file --&gt
 &ltfirstNode&gt
   content
 &lt/firstNode&gt


### PR DESCRIPTION
Changes:
- escaped special characters in the examples
- removed duplicated Noncompliant Example
- renamed "Noncompliant Example" to "Noncompliant Code Sample"  (SonarQube convention)
- added Compliant Solution