### PR TITLE
Fix for [SONARXML-23] and support for internal DTD declaration

### DIFF
--- a/xml-squid/src/main/java/org/sonar/xml/DoctypeTokenizer.java
+++ b/xml-squid/src/main/java/org/sonar/xml/DoctypeTokenizer.java
@@ -1,0 +1,206 @@
+/*
+ * SonarQube XML Plugin
+ * Copyright (C) 2010 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sonar.xml;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.sonar.channel.CodeReader;
+import org.sonar.colorizer.HtmlCodeBuilder;
+import org.sonar.colorizer.Tokenizer;
+
+/**
+ * This tokenizer takes care of DOCTYPE elements including declaration of internal DTDs, external DTDs and a 
+ * combination of both.
+ *
+ * @author Ren&eacute; Wolfert
+ */
+public class DoctypeTokenizer extends Tokenizer {
+
+  private static enum DoctypeParts {
+    Doctype("<!DOCTYPE", ">"),
+    DoctypeInternal("[", "]"),
+    Element("<!ELEMENT", ">"),
+    AttList("<!ATTLIST", ">");
+
+    private final String selectorStart;
+    private final String selectorEnd;
+
+    private final char[] selectorStartChars;
+    private final char[] selectorEndChars;
+
+    private DoctypeParts(final String selectorStart, final String selectorEnd) {
+      this.selectorStart = selectorStart;
+      this.selectorEnd = selectorEnd;
+
+      this.selectorStartChars = selectorStart.toCharArray();
+      this.selectorEndChars = selectorEnd.toCharArray();
+    }
+
+    public String getSelectorStart() {
+      return selectorStart;
+    }
+
+    public String getSelectorEnd() {
+      return selectorEnd;
+    }
+
+    public boolean matchesStartSelector(final CodeReader code) {
+      return code.peek() == selectorStartChars[0]
+          && Arrays.equals(code.peek(selectorStartChars.length), selectorStartChars);
+    }
+
+    public boolean matchesEndSelector(final CodeReader code) {
+      return code.peek() == selectorEndChars[0] && Arrays.equals(code.peek(selectorEndChars.length), selectorEndChars);
+    }
+  }
+
+  private static final String DOCTYPE_PART = "DOCTYPE_PARTS";
+  
+  private final String tagBefore;
+  private final String tagAfter;
+
+  public DoctypeTokenizer(final String tagBefore, final String tagAfter) {
+    this.tagBefore = tagBefore;
+    this.tagAfter = tagAfter;
+  }
+
+  @Override
+  public boolean consume(final CodeReader code, final HtmlCodeBuilder codeBuilder) {
+    final boolean consumed;
+    
+    if (getCurrentOpenedDoctypePart(codeBuilder) == null 
+        && DoctypeParts.Doctype.matchesStartSelector(code)) {
+      addOpenedDoctypePart(codeBuilder, DoctypeParts.Doctype);
+
+      codeBuilder.appendWithoutTransforming(tagBefore);
+      // Consume DOCTYPE start
+      code.popTo(Pattern.compile(Pattern.quote(DoctypeParts.Doctype.getSelectorStart())).matcher(""), codeBuilder);
+      codeBuilder.appendWithoutTransforming(tagAfter);
+      consumed = true;
+
+    } else if (DoctypeParts.Doctype == getCurrentOpenedDoctypePart(codeBuilder)
+        && DoctypeParts.DoctypeInternal.matchesStartSelector(code)) {
+      addOpenedDoctypePart(codeBuilder, DoctypeParts.DoctypeInternal);
+      consumed = true;
+
+    } else if (DoctypeParts.DoctypeInternal == getCurrentOpenedDoctypePart(codeBuilder)
+        && DoctypeParts.Element.matchesStartSelector(code)) {
+      addOpenedDoctypePart(codeBuilder, DoctypeParts.Element);
+
+      codeBuilder.appendWithoutTransforming(tagBefore);
+
+      // Consume ELEMENT start
+      code.popTo(Pattern.compile(Pattern.quote(DoctypeParts.Element.getSelectorStart())).matcher(""), codeBuilder);
+      codeBuilder.appendWithoutTransforming(tagAfter);
+      consumed = true;
+
+    } else if (DoctypeParts.DoctypeInternal == getCurrentOpenedDoctypePart(codeBuilder)
+        && DoctypeParts.AttList.matchesStartSelector(code)) {
+      addOpenedDoctypePart(codeBuilder, DoctypeParts.AttList);
+
+      codeBuilder.appendWithoutTransforming(tagBefore);
+
+      // Consume ATTLIST start
+      code.popTo(Pattern.compile(Pattern.quote(DoctypeParts.AttList.getSelectorStart())).matcher(""), codeBuilder);
+      codeBuilder.appendWithoutTransforming(tagAfter);
+      consumed = true;
+
+    } else if (DoctypeParts.AttList == getCurrentOpenedDoctypePart(codeBuilder)
+        && DoctypeParts.AttList.matchesEndSelector(code)) {
+      removeOpenedDoctypePart(codeBuilder, DoctypeParts.AttList);
+
+      codeBuilder.appendWithoutTransforming(tagBefore);
+      // Consume ATTLIST end
+      code.popTo(Pattern.compile(Pattern.quote(DoctypeParts.AttList.getSelectorEnd())).matcher(""), codeBuilder);
+      codeBuilder.appendWithoutTransforming(tagAfter);
+      consumed = true;
+
+    } else if (DoctypeParts.Element == getCurrentOpenedDoctypePart(codeBuilder)
+        && DoctypeParts.Element.matchesEndSelector(code)) {
+      removeOpenedDoctypePart(codeBuilder, DoctypeParts.Element);
+
+      codeBuilder.appendWithoutTransforming(tagBefore);
+      // Consume ELEMENT end
+      code.popTo(Pattern.compile(Pattern.quote(DoctypeParts.Element.getSelectorEnd())).matcher(""), codeBuilder);
+      codeBuilder.appendWithoutTransforming(tagAfter);
+      consumed = true;
+
+    } else if (DoctypeParts.DoctypeInternal == getCurrentOpenedDoctypePart(codeBuilder)
+        && DoctypeParts.DoctypeInternal.matchesEndSelector(code)) {
+      removeOpenedDoctypePart(codeBuilder, DoctypeParts.DoctypeInternal);
+      consumed = true;
+
+    } else if (DoctypeParts.Doctype == getCurrentOpenedDoctypePart(codeBuilder)
+        && DoctypeParts.Doctype.matchesEndSelector(code)) {
+      removeOpenedDoctypePart(codeBuilder, DoctypeParts.Doctype);
+
+      codeBuilder.appendWithoutTransforming(tagBefore);
+      // Consume DOCTYPE end
+      code.popTo(Pattern.compile(Pattern.quote(DoctypeParts.Doctype.getSelectorEnd())).matcher(""), codeBuilder);
+      codeBuilder.appendWithoutTransforming(tagAfter);
+      consumed = true;
+
+    } else if (getCurrentOpenedDoctypePart(codeBuilder) != null) {
+      code.pop(codeBuilder);
+      consumed = true;
+
+    } else {
+      consumed = false;
+    }
+
+    return consumed;
+  }
+
+  private DoctypeParts getCurrentOpenedDoctypePart(final HtmlCodeBuilder codeBuilder) {
+    final List<DoctypeParts> types = (List<DoctypeParts>) codeBuilder.getVariable(DoctypeTokenizer.DOCTYPE_PART, null);
+
+    final DoctypeParts openedDoctypePart;
+    if (types != null && !types.isEmpty()) {
+      openedDoctypePart = types.get(types.size() - 1);
+    } else {
+      openedDoctypePart = null;
+    }
+
+    return openedDoctypePart;
+  }
+
+  private void addOpenedDoctypePart(final HtmlCodeBuilder codeBuilder, final DoctypeParts type) {
+    final List<DoctypeParts> existingTypes = (List<DoctypeParts>) codeBuilder.getVariable(DoctypeTokenizer.DOCTYPE_PART, null);
+
+    final List<DoctypeParts> types = existingTypes != null ? existingTypes : new ArrayList<DoctypeParts>();
+
+    types.add(type);
+
+    codeBuilder.setVariable(DoctypeTokenizer.DOCTYPE_PART, types);
+  }
+
+  private void removeOpenedDoctypePart(final HtmlCodeBuilder codeBuilder, final DoctypeParts type) {
+    final List<DoctypeParts> existingTypes = (List<DoctypeParts>) codeBuilder.getVariable(DoctypeTokenizer.DOCTYPE_PART, null);
+
+    final List<DoctypeParts> types = existingTypes != null ? existingTypes : new ArrayList<DoctypeParts>();
+
+    if (!types.isEmpty()) {
+      types.remove(types.size() - 1);
+    }
+
+    codeBuilder.setVariable(DoctypeTokenizer.DOCTYPE_PART, types);
+  }
+}

--- a/xml-squid/src/main/java/org/sonar/xml/XmlColorizer.java
+++ b/xml-squid/src/main/java/org/sonar/xml/XmlColorizer.java
@@ -18,7 +18,6 @@
 package org.sonar.xml;
 
 import org.sonar.colorizer.MultilinesDocTokenizer;
-import org.sonar.colorizer.RegexpTokenizer;
 import org.sonar.colorizer.Tokenizer;
 
 import java.util.Arrays;
@@ -34,7 +33,7 @@ public final class XmlColorizer {
   public static List<Tokenizer> createTokenizers() {
     return Arrays.asList(
       new CDataDocTokenizer(span("k"), END_TAG),
-      new RegexpTokenizer(span("j"), END_TAG, "<!DOCTYPE.*>"),
+      new DoctypeTokenizer(span("j"), END_TAG),
       new MultilinesDocTokenizer("<!--", "-->", span("j"), END_TAG),
       new MultilinesDocTokenizer("</", ">", span("k"), END_TAG),
       new XmlStartElementTokenizer(span("k"), END_TAG, span("c"), END_TAG, span("s"), END_TAG));

--- a/xml-squid/src/test/java/org/sonar/xml/DoctypeTokenizerTest.java
+++ b/xml-squid/src/test/java/org/sonar/xml/DoctypeTokenizerTest.java
@@ -1,0 +1,110 @@
+/*
+ * SonarQube XML Plugin
+ * Copyright (C) 2010 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.sonar.xml;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertThat;
+
+import java.io.StringReader;
+
+import org.junit.Test;
+import org.sonar.colorizer.CodeColorizer;
+
+public class DoctypeTokenizerTest {
+
+  private final CodeColorizer codeColorizer = new CodeColorizer(XmlColorizer.createTokenizers());
+
+  private String highlight(final String webSourceCode) {
+    return codeColorizer.toHtml(new StringReader(webSourceCode));
+  }
+
+  @Test
+  public void testHighlightSingleLineDoctypeExternalDTD() {
+    final String input = "<!DOCTYPE web-app PUBLIC \"-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN\" \"http://java.sun.com/dtd/web-app_2_3.dtd\">";
+
+    final String highlightedText = highlight(input);
+    assertThat(highlightedText, containsString("<span class=\"j\">&lt;!DOCTYPE</span> web-app PUBLIC \"-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN\" \"http://java.sun.com/dtd/web-app_2_3.dtd\"<span class=\"j\">&gt;</span>"));
+  }
+
+  @Test
+  public void testHighlightMultiLineDoctypeExternalDTD() {
+    final String input = "<!DOCTYPE \r\n"
+        + "web-app PUBLIC \"-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN\" \r\n"
+        + "\"http://java.sun.com/dtd/web-app_2_3.dtd\">";
+
+    final String highlightedText = highlight(input);
+    assertThat(highlightedText, containsString("<span class=\"j\">&lt;!DOCTYPE</span>"));
+    assertThat(highlightedText, containsString("<pre>web-app PUBLIC \"-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN\" </pre>"));
+    assertThat(highlightedText, containsString("<pre>\"http://java.sun.com/dtd/web-app_2_3.dtd\"<span class=\"j\">&gt;</span></pre>"));
+  }
+
+  @Test
+  public void testHighlightSingleLineDoctypeInternalDTD() {
+    final String input = "<!DOCTYPE web-app [<!ELEMENT web-app (foo,bar)><!ELEMENT foo (#PCDATA)><!ELEMENT bar (#PCDATA)><!ATTLIST bar bar_value (A | B |C) #IMPLIED>]>";
+
+    final String highlightedText = highlight(input);
+    assertThat(highlightedText, containsString("<span class=\"j\">&lt;!DOCTYPE</span> web-app [<span class=\"j\">&lt;!ELEMENT</span> web-app (foo,bar)<span class=\"j\">&gt;</span><span class=\"j\">&lt;!ELEMENT</span> foo (#PCDATA)<span class=\"j\">&gt;</span><span class=\"j\">&lt;!ELEMENT</span> bar (#PCDATA)<span class=\"j\">&gt;</span><span class=\"j\">&lt;!ATTLIST</span> bar bar_value (A | B |C) #IMPLIED<span class=\"j\">&gt;</span>]<span class=\"j\">&gt;</span>"));
+  }
+
+  @Test
+  public void testHighlightMultiLineDoctypeInternalDTD() {
+    final String input = "<!DOCTYPE web-app [\r\n" + "<!ELEMENT web-app (foo,bar)>\r\n"
+        + "<!ELEMENT foo (#PCDATA)>\r\n" + "<!ELEMENT bar (#PCDATA)>\r\n"
+        + "<!ATTLIST bar bar_value (A | B |C) #IMPLIED>\r\n" + "]>";
+
+    final String highlightedText = highlight(input);
+    assertThat(highlightedText, containsString("<span class=\"j\">&lt;!DOCTYPE</span> web-app ["));
+    assertThat(highlightedText, containsString("<span class=\"j\">&lt;!ELEMENT</span> web-app (foo,bar)<span class=\"j\">&gt;</span>"));
+    assertThat(highlightedText, containsString("<span class=\"j\">&lt;!ELEMENT</span> foo (#PCDATA)<span class=\"j\">&gt;</span>"));
+    assertThat(highlightedText, containsString("<span class=\"j\">&lt;!ELEMENT</span> bar (#PCDATA)<span class=\"j\">&gt;</span>"));
+    assertThat(highlightedText, containsString("<span class=\"j\">&lt;!ATTLIST</span> bar bar_value (A | B |C) #IMPLIED<span class=\"j\">&gt;</span>"));
+    assertThat(highlightedText, containsString("]<span class=\"j\">&gt;</span>"));
+  }
+
+  @Test
+  public void testHighlightMultiLineWithXmlCommentDoctypeInternalDTD() {
+    final String input = "<!DOCTYPE web-app [\r\n" + "<!ELEMENT web-app (foo,bar)>\r\n"
+        + "<!ELEMENT foo (#PCDATA)>\r\n" + "<!-- Comment -->\r\n" + "<!ELEMENT bar (#PCDATA)>\r\n"
+        + "<!ATTLIST bar bar_value (A | B |C) #IMPLIED>\r\n" + "]>";
+
+    final String highlightedText = highlight(input);
+    assertThat(highlightedText, containsString("<span class=\"j\">&lt;!DOCTYPE</span> web-app ["));
+    assertThat(highlightedText, containsString("<span class=\"j\">&lt;!ELEMENT</span> web-app (foo,bar)<span class=\"j\">&gt;</span>"));
+    assertThat(highlightedText, containsString("<span class=\"j\">&lt;!ELEMENT</span> foo (#PCDATA)<span class=\"j\">&gt;</span>"));
+    assertThat(highlightedText, containsString("<span class=\"j\">&lt;!ELEMENT</span> bar (#PCDATA)<span class=\"j\">&gt;</span>"));
+    assertThat(highlightedText, containsString("<span class=\"j\">&lt;!ATTLIST</span> bar bar_value (A | B |C) #IMPLIED<span class=\"j\">&gt;</span>"));
+    assertThat(highlightedText, containsString("]<span class=\"j\">&gt;</span>"));
+  }
+
+  @Test
+  public void testHighlightMultiLineDoctypeInternalAndExternalDTD() {
+    final String input = "<!DOCTYPE web-app SYSTEM \"web-app.dtd\" [" + "<!ELEMENT web-app (foo,bar)>\r\n"
+        + "<!ELEMENT foo (#PCDATA)>\r\n" + "<!ELEMENT bar (#PCDATA)>\r\n"
+        + "<!ATTLIST bar bar_value (A | B |C) #IMPLIED>\r\n" + "]>";
+
+    final String highlightedText = highlight(input);
+    assertThat(highlightedText, containsString("<span class=\"j\">&lt;!DOCTYPE</span> web-app SYSTEM \"web-app.dtd\" ["));
+    assertThat(highlightedText, containsString("<span class=\"j\">&lt;!ELEMENT</span> web-app (foo,bar)<span class=\"j\">&gt;</span>"));
+    assertThat(highlightedText, containsString("<span class=\"j\">&lt;!ELEMENT</span> foo (#PCDATA)<span class=\"j\">&gt;</span>"));
+    assertThat(highlightedText, containsString("<span class=\"j\">&lt;!ELEMENT</span> bar (#PCDATA)<span class=\"j\">&gt;</span>"));
+    assertThat(highlightedText, containsString("<span class=\"j\">&lt;!ATTLIST</span> bar bar_value (A | B |C) #IMPLIED<span class=\"j\">&gt;</span>"));
+    assertThat(highlightedText, containsString("]<span class=\"j\">&gt;</span>"));
+
+  }
+}

--- a/xml-squid/src/test/java/org/sonar/xml/XmlCodeColorizerFormatTest.java
+++ b/xml-squid/src/test/java/org/sonar/xml/XmlCodeColorizerFormatTest.java
@@ -112,7 +112,7 @@ public class XmlCodeColorizerFormatTest {
 
   @Test
   public void testHighlightDoctype() {
-    assertThat(highlight("<!DOCTYPE foo bar >"), containsString("<span class=\"j\">&lt;!DOCTYPE foo bar &gt;</span>"));
+    assertThat(highlight("<!DOCTYPE foo bar >"), containsString("<span class=\"j\">&lt;!DOCTYPE</span> foo bar <span class=\"j\">&gt;</span>"));
   }
 
   private String highlight(String webSourceCode) {


### PR DESCRIPTION
Implemented tokenizer for highlighting of DOCTYPE which supports multiline DOCTYPE elements (SONARXML-23) and has support for DTD declaration inside the DOCTYPE element