### PR TITLE
S1778 small documentation fixes

### DIFF
--- a/sonar-xml-plugin/src/main/resources/org/sonar/l10n/xml/rules/xml/S1778.html
+++ b/sonar-xml-plugin/src/main/resources/org/sonar/l10n/xml/rules/xml/S1778.html
@@ -16,7 +16,7 @@ Because each XML entity not accompanied by external encoding information and not
 <pre>
 &lt;!-- Generated file --&gt;
 &lt;?xml version="1.0" encoding="UTF-8"?&gt;
-&lt;firstNode&gt;;
+&lt;firstNode&gt;
   content
 &lt;/firstNode&gt;
 </pre>


### PR DESCRIPTION
Hi,
I removed redundant ';' character in the S1778 rule documentation.

Regards,
   Adam Gabryś